### PR TITLE
Add policy definition to enforce naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The content of the **Azure-samples/Governance** repository is structured as foll
 | File/folder          | Description                                |
 |----------------------|--------------------------------------------|
 | `src`                | Samples root folder.                       |
+| -- `policy`          | Samples for [Azure Policy](https://learn.microsoft.com/azure/governance/policy/). |
 | -- `resource-graph`  | Samples for [Azure Resource Graph](https://docs.microsoft.com/azure/governance/resource-graph). |
 | `.gitignore`         | Define what to ignore at commit time.      |
 | `CHANGELOG.md`       | List of changes to the sample.             |

--- a/src/policy/README.md
+++ b/src/policy/README.md
@@ -1,0 +1,28 @@
+---
+page_type: overview
+products:
+- azure-policy
+description: "Samples for the Azure Governance - Azure Policy service"
+urlFragment: "update-this-to-unique-url-stub"
+---
+
+# Azure Governance - Azure Policy samples
+
+Samples and examples used by Azure Governance docs, demos, and presentations specific to Azure Policy.
+
+## Contents
+
+The content of the [Azure Policy](https://learn.microsoft.com/azure/governance/policy/)
+samples is structured as follows:
+
+| File/folder          | Description                                                    |
+|----------------------|----------------------------------------------------------------|
+| `naming-convention`  | Sample Azure policy definition to enforce a naming convention. |
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/src/policy/naming-convention/README.md
+++ b/src/policy/naming-convention/README.md
@@ -16,8 +16,8 @@ This Azure policy governs the naming convention for virtual machines within the 
 
 ### Azure Portal
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/)
-[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2FGovernance%2Fmaster%2Fsrc%2Fpolicy%2Fnaming-convention%2Fpolicy.json)
+[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2FGovernance%2Fmaster%2Fsrc%2Fpolicy%2Fnaming-convention%2Fpolicy.json)
 
 ### Azure PowerShell
 
@@ -27,8 +27,8 @@ $definition = New-AzPolicyDefinition `
     -Name 'Naming_VirtualMachine_Deny' `
     -DisplayName 'Naming_VirtualMachine_Deny' `
     -Description 'This policy governs the naming convention for virtual machines.' `
-    -Policy '' `
-    -Parameter '' `
+    -Policy 'https://raw.githubusercontent.com/Azure-Samples/Governance/master/src/policy/naming-convention/policy.rules.json' `
+    -Parameter 'https://raw.githubusercontent.com/Azure-Samples/Governance/master/src/policy/naming-convention/policy.parameters.json' `
     -Mode 'All' `
     -Metadata '{"category":"Governance"}'
 
@@ -51,8 +51,8 @@ az policy definition create \
     --name 'Naming_VirtualMachine_Deny' \
     --display-name 'Naming_VirtualMachine_Deny' \
     --description 'This policy governs the naming convention for virtual machines.' \
-    --rules '' \
-    --params '' \
+    --rules 'https://raw.githubusercontent.com/Azure-Samples/Governance/master/src/policy/naming-convention/policy.rules.json' \
+    --params 'https://raw.githubusercontent.com/Azure-Samples/Governance/master/src/policy/naming-convention/policy.parameters.json' \
     --mode All
 
 az policy assignment create \

--- a/src/policy/naming-convention/README.md
+++ b/src/policy/naming-convention/README.md
@@ -1,0 +1,63 @@
+---
+page_type: sample
+languages:
+- json
+products:
+- azure-policy
+description: "An Azure policy definition that enforces a naming convention on Azure virtual machines."
+urlFragment: "update-this-to-unique-url-stub"
+---
+
+# Enforce Azure virtual machine names based on a naming convention
+
+This Azure policy governs the naming convention for virtual machines within the specified scope. The policy was developed to support a 3 tier application in 2 locations that all reside in the same resource group. Ideally, this policy would be assigned to a resource group when the resource group is created.
+
+## Deployment Options
+
+### Azure Portal
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/)
+[![Deploy to Azure Gov](https://aka.ms/deploytoazuregovbutton)](https://portal.azure.us/?#blade/Microsoft_Azure_Policy/CreatePolicyDefinitionBlade/uri/)
+
+### Azure PowerShell
+
+````powershell
+
+$definition = New-AzPolicyDefinition `
+    -Name 'Naming_VirtualMachine_Deny' `
+    -DisplayName 'Naming_VirtualMachine_Deny' `
+    -Description 'This policy governs the naming convention for virtual machines.' `
+    -Policy '' `
+    -Parameter '' `
+    -Mode 'All' `
+    -Metadata '{"category":"Governance"}'
+
+New-AzPolicyAssignment `
+    -Name '<Assignment Name>' `
+    -Scope '<Scope>' `
+    -Application '<Application>' `
+    -Environment '<Environment Abbreviation>' `
+    -DataCenterCountry '<Data Center Country>' `
+    -DataCenterLocation '<Primary Location Abbreviation>' `
+    -PolicyDefinition $definition
+
+````
+
+### Azure CLI
+
+````cli
+
+az policy definition create \
+    --name 'Naming_VirtualMachine_Deny' \
+    --display-name 'Naming_VirtualMachine_Deny' \
+    --description 'This policy governs the naming convention for virtual machines.' \
+    --rules '' \
+    --params '' \
+    --mode All
+
+az policy assignment create \
+    --name <Assignment Name> \
+    --scope <scope> \
+    --policy "Naming_VirtualMachine_Deny"
+
+````

--- a/src/policy/naming-convention/policy.json
+++ b/src/policy/naming-convention/policy.json
@@ -1,0 +1,163 @@
+{
+    "properties": {
+        "mode": "All",
+        "displayName": "NamingStandard_VirtualMachine_Deny",
+        "description": "This policy governs the naming standard for virtual machines and should be assigned at the resource group scope.  The naming scheme is 'vm + app name / abbreviation + location + environment + app tier + ordinal'.  Each component of the naming scheme has a maximum allowed character length: resource type = 2, app name / abbreviation = 6, country = 2, region = 2, environment = 1, app tier = 1, ordinal = 1.  This scheme exhausts the max allowed characters (15) for a virtual machine name.",
+        "metadata": {
+            "category": "Governance"
+        },
+        "parameters": {
+            "Application": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 - 6 characters for the application name or abbreviation",
+                    "displayName": "Application Name or Abbreviation"
+                }
+            },
+            "Environment": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 character for the environment abbreviation: 'd' = Dev, 'p' = Production, 's' = Stage, & 't' = Test ",
+                    "displayName": "Environment Abbreviation"
+                },
+                "allowedValues": [
+                    "d",
+                    "p",
+                    "s",
+                    "t"
+                ]
+            },
+            "DataCenterCountry": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 2 characters to abbreviate the Azure country (e.g., 'us' for United States or 'ca' for Canada).",
+                    "displayName": "Data Center Country Abbreviation"
+                },
+                "defaultValue": "us",
+                "allowedValues": [
+                    "ae",
+                    "at",
+                    "au",
+                    "br",
+                    "ca",
+                    "ch",
+                    "cl",
+                    "cn",
+                    "de",
+                    "dk",
+                    "es",
+                    "fr",
+                    "gb",
+                    "gr",
+                    "hk",
+                    "ie",
+                    "il",
+                    "in",
+                    "it",
+                    "jp",
+                    "kr",
+                    "mx",
+                    "nl",
+                    "no",
+                    "nz",
+                    "pl",
+                    "qa",
+                    "se",
+                    "sg",
+                    "tw",
+                    "us",
+                    "za"
+                ]
+            },
+            "DataCenterLocation": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 - 2 characters to abbreviate the Azure location (e.g., 'e' for East US or 'e2' for East US 2).",
+                    "displayName": "Data Center Location Abbreviation"
+                },
+                "allowedValues": [
+                    "e",
+                    "e2",
+                    "e3",
+                    "c",
+                    "c2",
+                    "dc",
+                    "de",
+                    "ga",
+                    "gt",
+                    "gv",
+                    "n",
+                    "n2",
+                    "nc",
+                    "ne",
+                    "s",
+                    "sc",
+                    "se",
+                    "w",
+                    "w2",
+                    "w3",
+                    "wc"
+                ]
+            },
+            "WebTier": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 character to abbreviate the web or presentation tier: 'p' = Presentation & 'w' = Web",
+                    "displayName": "Web Tier Abbreviation"
+                },
+                "defaultValue": "w",
+                "allowedValues": [
+                    "w",
+                    "p"
+                ]
+            },
+            "LogicTier": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 character to abbreviate the business logic tier:  'l' = Logic.",
+                    "displayName": "Logic Tier Abbreviation"
+                },
+                "defaultValue": "l",
+                "allowedValues": [
+                    "l"
+                ]
+            },
+            "DataTier": {
+                "type": "String",
+                "metadata": {
+                    "description": "Use 1 character to abbreviate the database tier: 'd' = Database.",
+                    "displayName": "Data Tier Abbreviation"
+                },
+                "defaultValue": "d",
+                "allowedValues": [
+                    "d"
+                ]
+            }
+        },
+        "policyRule": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "name",
+                        "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('WebTier'), '#')]"
+                    },
+                    {
+                        "field": "name",
+                        "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('LogicTier'), '#')]"
+                    },
+                    {
+                        "field": "name",
+                        "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('DataTier'), '#')]"
+                    },
+                    {
+                        "field": "type",
+                        "equals": "Microsoft.Compute/virtualMachines"
+                    }
+                ]
+            },
+            "then": {
+                "effect": "deny"
+            }
+        }
+    }
+}

--- a/src/policy/naming-convention/policy.parameters.json
+++ b/src/policy/naming-convention/policy.parameters.json
@@ -1,0 +1,128 @@
+{
+    "Application": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 - 6 characters for the application name or abbreviation",
+            "displayName": "Application Name or Abbreviation"
+        }
+    },
+    "Environment": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 character for the environment abbreviation: 'd' = Dev, 'p' = Production, 's' = Stage, & 't' = Test ",
+            "displayName": "Environment Abbreviation"
+        },
+        "allowedValues": [
+            "d",
+            "p",
+            "s",
+            "t"
+        ]
+    },
+    "DataCenterCountry": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 2 characters to abbreviate the Azure country (e.g., 'us' for United States or 'ca' for Canada).",
+            "displayName": "Data Center Country Abbreviation"
+        },
+        "defaultValue": "us",
+        "allowedValues": [
+            "ae",
+            "at",
+            "au",
+            "br",
+            "ca",
+            "ch",
+            "cl",
+            "cn",
+            "de",
+            "dk",
+            "es",
+            "fr",
+            "gb",
+            "gr",
+            "hk",
+            "ie",
+            "il",
+            "in",
+            "it",
+            "jp",
+            "kr",
+            "mx",
+            "nl",
+            "no",
+            "nz",
+            "pl",
+            "qa",
+            "se",
+            "sg",
+            "tw",
+            "us",
+            "za"
+        ]
+    },
+    "DataCenterLocation": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 - 2 characters to abbreviate the Azure location (e.g., 'e' for East US or 'e2' for East US 2).",
+            "displayName": "Data Center Location Abbreviation"
+        },
+        "allowedValues": [
+            "e",
+            "e2",
+            "e3",
+            "c",
+            "c2",
+            "dc",
+            "de",
+            "ga",
+            "gt",
+            "gv",
+            "n",
+            "n2",
+            "nc",
+            "ne",
+            "s",
+            "sc",
+            "se",
+            "w",
+            "w2",
+            "w3",
+            "wc"
+        ]
+    },
+    "WebTier": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 character to abbreviate the web or presentation tier: 'p' = Presentation & 'w' = Web",
+            "displayName": "Web Tier Abbreviation"
+        },
+        "defaultValue": "w",
+        "allowedValues": [
+            "w",
+            "p"
+        ]
+    },
+    "LogicTier": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 character to abbreviate the business logic tier:  'l' = Logic.",
+            "displayName": "Logic Tier Abbreviation"
+        },
+        "defaultValue": "l",
+        "allowedValues": [
+            "l"
+        ]
+    },
+    "DataTier": {
+        "type": "String",
+        "metadata": {
+            "description": "Use 1 character to abbreviate the database tier: 'd' = Database.",
+            "displayName": "Data Tier Abbreviation"
+        },
+        "defaultValue": "d",
+        "allowedValues": [
+            "d"
+        ]
+    }
+}

--- a/src/policy/naming-convention/policy.rules.json
+++ b/src/policy/naming-convention/policy.rules.json
@@ -1,0 +1,25 @@
+{
+    "if": {
+        "allOf": [
+            {
+                "field": "name",
+                "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('WebTier'), '#')]"
+            },
+            {
+                "field": "name",
+                "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('LogicTier'), '#')]"
+            },
+            {
+                "field": "name",
+                "notMatch": "[concat('vm', parameters('Application'), parameters('DataCenterCountry'), parameters('DataCenterLocation'), parameters('Environment'), parameters('DataTier'), '#')]"
+            },
+            {
+                "field": "type",
+                "equals": "Microsoft.Compute/virtualMachines"
+            }
+        ]
+    },
+    "then": {
+        "effect": "deny"
+    }
+}


### PR DESCRIPTION
Adding a sample policy definition to enforce an Azure naming convention on virtual machines. This sample will be referenced in the CAF govern documentation once published.